### PR TITLE
그리드 사용해서 2행 4열 카드 리스트 생성

### DIFF
--- a/02-css/grid-shopping-card-list/index.html
+++ b/02-css/grid-shopping-card-list/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <link href="styles.css" rel="stylesheet" />
+</head>
+<body>
+    <h1>찜목록</h1>
+    <main>
+        <topWrapper>
+            <product>
+                <img src="https://via.assets.so/img.jpg?w=200&h=200&tc=blue&bg=#cecece"/>
+                <div>상품이름1</div>
+                <div>1000</div>
+            </product>
+            <product>
+                <img src="https://via.assets.so/img.jpg?w=200&h=200&tc=blue&bg=#cecece"/>
+                <div>상품이름2</div>
+                <div>2000</div>
+            </product>
+            <product>
+                <img src="https://via.assets.so/img.jpg?w=200&h=200&tc=blue&bg=#cecece"/>
+                <div>상품이름3</div>
+                <div>3000</div>
+            </product>
+            <product>
+                <img src="https://via.assets.so/img.jpg?w=200&h=200&tc=blue&bg=#cecece"/>
+                <div>상품이름4</div>
+                <div>4000</div>
+            </product>
+            <product>
+                <img src="https://via.assets.so/img.jpg?w=200&h=200&tc=blue&bg=#cecece"/>
+                <div>상품이름5</div>
+                <div>5000</div>
+            </product>
+            <product>
+                <img src="https://via.assets.so/img.jpg?w=200&h=200&tc=blue&bg=#cecece"/>
+                <div>상품이름6</div>
+                <div>6000</div>
+            </product>
+            <product>
+                <img src="https://via.assets.so/img.jpg?w=200&h=200&tc=blue&bg=#cecece"/>
+                <div>상품이름7</div>
+                <div>7000</div>
+            </product>
+            <product>
+                <img src="https://via.assets.so/img.jpg?w=200&h=200&tc=blue&bg=#cecece"/>
+                <div>상품이름8</div>
+                <div>8000</div>
+            </product>
+        </topWrapper>
+        <bottomWrapper>
+            <button>찜목록 더보기</button>
+        </bottomWrapper>
+    </main>
+</body>
+</html>

--- a/02-css/grid-shopping-card-list/styles.css
+++ b/02-css/grid-shopping-card-list/styles.css
@@ -1,0 +1,16 @@
+main {
+    width: 1000px;
+    height: 1000px;
+    display: flex;
+    flex-direction: column;
+}
+
+topWrapper {
+    width: 800px;
+    height: 800px;
+    border: 1px solid red;
+    display: grid;
+    row-gap: 40px;
+    column-gap: 20px;
+    grid-template-columns: 200px 200px 200px 200px;
+}


### PR DESCRIPTION
#34
- [x] 그리드 사용해서 2행 4열 카드 리스트 생성
- [x] grid-template-columns를 사용하여 4열 그리드 생성
- [x] 아이템이 8개 이므로 grid-template-columns가 200px 200px 200px 200px 이면 한 행에 4개카드씩 2개 열 생성

스크린샷
![image](https://github.com/user-attachments/assets/8f74711e-00e1-4209-be68-c9805266ed23)
